### PR TITLE
Run E2E tests against "notable" versions

### DIFF
--- a/.github/workflows/e2e_minmax.yml
+++ b/.github/workflows/e2e_minmax.yml
@@ -1,10 +1,10 @@
-name: Full E2E test
+name: E2E test
 
 on:
   workflow_dispatch:
   push:
-    tags:
-      - 'v*.*.*'
+    branches:
+      - main
 
 jobs:
   build:
@@ -14,25 +14,13 @@ jobs:
     name: E2E test
     needs: build
     strategy:
-      fail-fast: false
       matrix:
         version:
           - 1.19.3
-          - 1.18.2
-          - 1.17.1
-          - 1.16.5
-          - 1.15.2
-          - 1.14.4
-          - 1.13.2
-          - 1.12.2
-          - 1.11.2
-          - 1.10.2
-          - 1.9.4
           - 1.8.9
         proxy:
           - velocity
           - bungeecord
-          - waterfall
     uses: ./.github/workflows/e2e_test.yml
     with:
       proxy: ${{ matrix.proxy }}

--- a/.github/workflows/e2e_minmax.yml
+++ b/.github/workflows/e2e_minmax.yml
@@ -2,6 +2,9 @@ name: E2E test
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main

--- a/.github/workflows/e2e_notable.yml
+++ b/.github/workflows/e2e_notable.yml
@@ -20,6 +20,10 @@ jobs:
       matrix:
         version:
           - 1.19.3
+          - 1.16.5
+          - 1.16.3
+          - 1.13.2
+          - 1.12.2
           - 1.8.9
         proxy:
           - velocity

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
   <a href="https://github.com/turikhay/MapModCompanion/blob/main/LICENSE.txt">
     <img src="https://img.shields.io/github/license/turikhay/MapModCompanion">
   </a>
-  <a href="https://github.com/turikhay/MapModCompanion/actions/workflows/e2e_minmax.yml">
-    <img src="https://github.com/turikhay/MapModCompanion/actions/workflows/e2e_minmax.yml/badge.svg" />
+  <a href="https://github.com/turikhay/MapModCompanion/actions/workflows/e2e_notable.yml">
+    <img src="https://github.com/turikhay/MapModCompanion/actions/workflows/e2e_notable.yml/badge.svg" />
   </a>
   <a href="https://modrinth.com/plugin/modmapcompanion">
     <img src="https://img.shields.io/modrinth/dt/UO7aDcrF?label=Modrinth%20%28downloads%29" />


### PR DESCRIPTION
Partially reverts #24, because 30+ tests fail too often.