### PR TITLE
Add explicit jackson dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ bstats-bungeecord = { module = "org.bstats:bstats-bungeecord", version.ref = "bs
 bstats-bukkit = { module = "org.bstats:bstats-bukkit", version.ref = "bstats" }
 bstats-velocity = { module = "org.bstats:bstats-velocity", version.ref = "bstats" }
 velocity-api = { module = "com.velocitypowered:velocity-api", version.ref = "velocity-api" }
+jackson-core = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jackson" }
 
 
 [plugins]


### PR DESCRIPTION
Add explicit jackson-core dependency. We implicitly use it in the `buildSrc`:

https://github.com/turikhay/MapModCompanion/blob/7e13a5c6c6b373d6fa85209dfce0c42364bd34ea/buildSrc/build.gradle.kts#L13-L17

With this small "hack" in place, dependabot will be able to upgrade this dependency automatically. I expect all jackson projects update simultaneously.