### PR TITLE
Submit Dependency Graph

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,9 @@ on:
         description: Path to the jar artifact
         value: ${{ jobs.build.outputs.artifact }}
 
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Gradle build
@@ -23,25 +26,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          dependency-graph: generate-and-submit
       - name: Determine target Spigot version
         id: target
         run: |
           TARGET=${{ inputs.spigot-target }}
           [[ -z "$TARGET" ]] && TARGET=$(tail -n1 VERSIONS.txt)
           echo "spigot-version=$TARGET" >> $GITHUB_OUTPUT
-      - uses: gradle/gradle-build-action@v2
-        with:
-          arguments: |
-            build
-            -Pversion=${{ inputs.version }}
-            -Pspigot_version=${{ steps.target.outputs.spigot-version }}
-            -PprotocolLib_version=4.2.1
+      - name: Run the build
+        run: |
+          ./gradlew
+          build
+          -Pversion=${{ inputs.version }}
+          -Pspigot_version=${{ steps.target.outputs.spigot-version }}
+          -PprotocolLib_version=4.2.1
       - name: Force original path preservation (for upload-artifact@v3)
         run: touch .empty
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,10 +40,10 @@ jobs:
           echo "spigot-version=$TARGET" >> $GITHUB_OUTPUT
       - name: Run the build
         run: |
-          ./gradlew
-          build
-          -Pversion=${{ inputs.version }}
-          -Pspigot_version=${{ steps.target.outputs.spigot-version }}
+          ./gradlew \
+          build \
+          -Pversion=${{ inputs.version }} \
+          -Pspigot_version=${{ steps.target.outputs.spigot-version }} \
           -PprotocolLib_version=4.2.1
       - name: Force original path preservation (for upload-artifact@v3)
         run: touch .empty


### PR DESCRIPTION
> The gradle-build-action has support for submitting a [GitHub Dependency Graph](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-the-dependency-graph) snapshot via the [GitHub Dependency Submission API](https://docs.github.com/en/rest/dependency-graph/dependency-submission?apiVersion=2022-11-28).

[[1]](https://github.com/gradle/gradle-build-action/tree/42452daeb5b454a76f686a8e4de8234afd7b1f44#github-dependency-graph-support)