### PR TITLE
Rename the job left from copy-pasting

### DIFF
--- a/.github/workflows/update-pages.yml
+++ b/.github/workflows/update-pages.yml
@@ -20,7 +20,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
-      - name: Run the build
+      - name: Run tasks
         run: |
           ./gradlew \
           modrinthSyncBody \


### PR DESCRIPTION
`Run the build` should be `Run tasks`