### PR TITLE
Upgrade gradle-build-action@v2 to gradle/actions/setup-gradle@v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           dependency-graph: generate-and-submit
       - name: Determine target Spigot version


### PR DESCRIPTION
`gradle/actions/setup-gradle` replaces `gradle-build-action`

See: [[1]](https://github.com/gradle/actions/blob/5b6457b09bea73ff064cfca8e850c64701ea9cb8/README.md#the-setup-gradle-action) [[2]](https://github.com/gradle/gradle-build-action/blob/ef85c4ed42c6bd3e2d9deb8edcba57e41360968b/README.md)