### PR TITLE
remove repo token

### DIFF
--- a/.github/workflows/update-gradle.yml
+++ b/.github/workflows/update-gradle.yml
@@ -14,5 +14,3 @@ jobs:
 
       - name: Update Gradle Wrapper
         uses: gradle-update/update-gradle-wrapper-action@v1
-        with:
-          repo-token: ${{ secrets.GRADLE_UPDATE_TOKEN }}


### PR DESCRIPTION
[According to the docs](https://github.com/gradle-update/update-gradle-wrapper-action/blob/f0a708cf2ee01e34c7092100e20cf3e2f3af4e1c/README.md#usage), we don't actually need passing GitHub token.