### PR TITLE
Upgrade Hangar plugin to 0.1.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ bstats = "3.0.2"
 velocity-api = "3.1.1"
 jackson = "2.16.1"
 semver = "1.3.0"
-hangar = "0.1.1"
+hangar = "0.1.2"
 bungeecord-api = "1.20-R0.2"
 
 [libraries]


### PR DESCRIPTION
This will bring Gradle 8.6 support.

0.1.1 fails, see [corresponding action run](https://github.com/turikhay/MapModCompanion/actions/runs/7769592482):

```
  BUILD FAILED in 1m 6s
  10 actionable tasks: 10 executed
  Error: ❌ FAILURE: Build failed with an exception.
  
  * Where:
  Build file '/home/runner/work/MapModCompanion/MapModCompanion/packages/single/build.gradle.kts' line: 59
  
  * What went wrong:
  Could not create domain object 'plugin' (HangarPublicationImpl)
  > Could not create an instance of type io.papermc.hangarpublishplugin.internal.model.HangarPublicationImpl.
     > Could not create an instance of type io.papermc.hangarpublishplugin.internal.model.PlatformContainerImpl.
        > Could not generate a decorated class for type PlatformContainerImpl.
           > Cannot have abstract method NamedDomainObjectSet.named().
```