### PR TITLE
Deduplicate output jar files

### DIFF
--- a/buildSrc/src/main/kotlin/ProjectExt.kt
+++ b/buildSrc/src/main/kotlin/ProjectExt.kt
@@ -11,6 +11,4 @@ val Project.libs get() = the<org.gradle.accessors.dm.LibrariesForLibs>()
 
 val Task.singleFile get() = outputs.files.singleFile
 
-val <T : Task> TaskProvider<T>.singleFile get(): Provider<File> = this.map {
-    it.outputs.files.singleFile
-}
+val <T : Task> TaskProvider<T>.singleFile get() = map { it.singleFile }

--- a/buildSrc/src/main/kotlin/ProjectExt.kt
+++ b/buildSrc/src/main/kotlin/ProjectExt.kt
@@ -1,5 +1,17 @@
 import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.TaskOutputs
+import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.the
+import java.io.File
 
 // See https://github.com/gradle/gradle/issues/15383
 val Project.libs get() = the<org.gradle.accessors.dm.LibrariesForLibs>()
+
+val Task.singleFile get() = outputs.files.singleFile
+
+val <T : Task?> TaskProvider<T>.singleFile get(): Provider<File> = this.map {
+    @Suppress("UNNECESSARY_NOT_NULL_ASSERTION")
+    it!!.outputs.files.singleFile
+}

--- a/buildSrc/src/main/kotlin/ProjectExt.kt
+++ b/buildSrc/src/main/kotlin/ProjectExt.kt
@@ -11,7 +11,6 @@ val Project.libs get() = the<org.gradle.accessors.dm.LibrariesForLibs>()
 
 val Task.singleFile get() = outputs.files.singleFile
 
-val <T : Task?> TaskProvider<T>.singleFile get(): Provider<File> = this.map {
-    @Suppress("UNNECESSARY_NOT_NULL_ASSERTION")
-    it!!.outputs.files.singleFile
+val <T : Task> TaskProvider<T>.singleFile get(): Provider<File> = this.map {
+    it.outputs.files.singleFile
 }

--- a/buildSrc/src/main/kotlin/java-shadow.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-shadow.gradle.kts
@@ -4,45 +4,30 @@ plugins {
 }
 
 tasks {
-    assemble {
-        dependsOn(shadowJar)
-    }
-
-    val createDedupJar = register<Jar>("createDedupJar") {
-        from(shadowJar.map { zipTree(it.singleFile) })
-        archiveFileName = shadowJar.map {
-            it.archiveFileName.get().replace(".jar", "-dedup.jar")
-        }
-        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    }
-
-    val copyBackDedupJar = register("copyBackDedupJar") {
-        dependsOn(createDedupJar)
-        doLast {
-            createDedupJar.singleFile.get().copyTo(
-                    shadowJar.singleFile.get(),
-                    overwrite = true
-            )
-        }
-    }
-
-    val dedupShadowJar = register("dedupShadowJar") {
-        dependsOn(shadowJar, createDedupJar, copyBackDedupJar)
-    }
-
     shadowJar {
         archiveFileName = "MapModCompanion-${
             project.name.replaceFirstChar {
                 it.uppercaseChar()
             }
-        }.jar"
+        }-shadow.jar"
         
         listOf(
             "org.bstats",
         ).forEach { pkg ->
             relocate(pkg, with(rootProject) { "${group}.${name}.shade.${pkg}" })
         }
+    }
 
-        finalizedBy(dedupShadowJar)
+    val dedupShadowJar = register<Jar>("dedupShadowJar") {
+        dependsOn(shadowJar)
+        from(shadowJar.map { zipTree(it.singleFile) })
+        archiveFileName = shadowJar.map {
+            it.archiveFileName.get().replace("-shadow.jar", ".jar")
+        }
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    }
+
+    assemble {
+        dependsOn(dedupShadowJar)
     }
 }

--- a/buildSrc/src/main/kotlin/java-shadow.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-shadow.gradle.kts
@@ -8,6 +8,28 @@ tasks {
         dependsOn(shadowJar)
     }
 
+    val createDedupJar = register<Jar>("createDedupJar") {
+        from(shadowJar.map { zipTree(it.singleFile) })
+        archiveFileName = shadowJar.map {
+            it.archiveFileName.get().replace(".jar", "-dedup.jar")
+        }
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    }
+
+    val copyBackDedupJar = register("copyBackDedupJar") {
+        dependsOn(createDedupJar)
+        doLast {
+            createDedupJar.singleFile.get().copyTo(
+                    shadowJar.singleFile.get(),
+                    overwrite = true
+            )
+        }
+    }
+
+    val dedupShadowJar = register("dedupShadowJar") {
+        dependsOn(shadowJar, createDedupJar, copyBackDedupJar)
+    }
+
     shadowJar {
         archiveFileName = "MapModCompanion-${
             project.name.replaceFirstChar {
@@ -20,5 +42,7 @@ tasks {
         ).forEach { pkg ->
             relocate(pkg, with(rootProject) { "${group}.${name}.shade.${pkg}" })
         }
+
+        finalizedBy(dedupShadowJar)
     }
 }

--- a/packages/single/build.gradle.kts
+++ b/packages/single/build.gradle.kts
@@ -71,7 +71,7 @@ hangarPublish {
         changelog = commonChangelog
         apiKey = System.getenv("HANGAR_TOKEN")
         platforms {
-            val singleJar = tasks.getByName("dedupShadowJar").singleFile
+            val singleJar = dedupShadowJar.singleFile
             val families = allVersions.map {
                 val split = it.split(".") // -> 1, 20[, 4]
                 assert(split.size > 1)

--- a/packages/single/build.gradle.kts
+++ b/packages/single/build.gradle.kts
@@ -43,7 +43,7 @@ modrinth {
     if (updatePages) {
         syncBodyFrom = platformReadme
     }
-    uploadFile = tasks.getByName("dedupShadowJar")
+    file = dedupShadowJar.singleFile
     gameVersions = allVersions
     loaders.addAll(listOf(
             "bukkit",

--- a/packages/single/build.gradle.kts
+++ b/packages/single/build.gradle.kts
@@ -42,7 +42,7 @@ modrinth {
     if (updatePages) {
         syncBodyFrom = platformReadme
     }
-    uploadFile = tasks.getByPath("shadowJar")
+    uploadFile = tasks.getByName("dedupShadowJar")
     gameVersions = allVersions
     loaders.addAll(listOf(
             "bukkit",
@@ -70,7 +70,7 @@ hangarPublish {
         changelog = commonChangelog
         apiKey = System.getenv("HANGAR_TOKEN")
         platforms {
-            val singleJar = tasks.shadowJar.map { it.outputs.files.singleFile }
+            val singleJar = tasks.getByName("dedupShadowJar").singleFile
             val families = allVersions.map {
                 val split = it.split(".") // -> 1, 20[, 4]
                 assert(split.size > 1)
@@ -109,18 +109,20 @@ hangarPublish {
 }
 
 tasks {
+    val dedupShadowJar by named("dedupShadowJar")
+
     shadowJar {
-        archiveFileName = "MapModCompanion.jar"
+        archiveFileName = "MapModCompanion-shadow.jar"
     }
     getByName("modrinth") {
         dependsOn(
-                shadowJar,
+                dedupShadowJar,
                 modrinthSyncBody
         )
     }
     getByName("publishPluginPublicationToHangar") {
         dependsOn(
-                shadowJar,
+                dedupShadowJar,
                 getByName("syncAllPluginPublicationPagesToHangar")
         )
     }

--- a/packages/single/build.gradle.kts
+++ b/packages/single/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     implementation(project(":velocity"))
 }
 
+val dedupShadowJar by tasks.named("dedupShadowJar")
 val semVer = SemVer.parse(project.version as String)
 val isRelease = semVer.preRelease == null
 val updatePages = isRelease || System.getenv("UPDATE_PAGES") == "true"
@@ -109,8 +110,6 @@ hangarPublish {
 }
 
 tasks {
-    val dedupShadowJar by named("dedupShadowJar")
-
     shadowJar {
         archiveFileName = "MapModCompanion-shadow.jar"
     }

--- a/velocity/build.gradle.kts
+++ b/velocity/build.gradle.kts
@@ -34,6 +34,6 @@ tasks {
     }
 
     shadowJar {
-        archiveFileName = "mapmodcompanion.jar"
+        archiveFileName = "mapmodcompanion-shadow.jar"
     }
 }


### PR DESCRIPTION
Closes #117 

New Paper remapper doesn't like duplicate entries in the plugin jar. I came up with a simple and a bit naive solution: we take output of `shadowJar` and create a new jar with `DuplicatesStrategy.EXCLUDE` set, and then replace the original one.

EDIT: We should avoid replacing original jar; it's better to just use `dedupShadowJar` output instead