### PR TITLE
Migrate to lazy providers

### DIFF
--- a/packages/single/build.gradle.kts
+++ b/packages/single/build.gradle.kts
@@ -116,10 +116,8 @@ tasks {
     getByName("modrinth") {
         dependsOn(
                 dedupShadowJar,
+                modrinthSyncBody
         )
-        if (updatePages) {
-            dependsOn(modrinthSyncBody)
-        }
     }
     getByName("publishPluginPublicationToHangar") {
         dependsOn(


### PR DESCRIPTION
I've used Kotlin `lazy` properties for "heavy" tasks but it's better to use native Gradle providers.