### PR TITLE
fix api-version

### DIFF
--- a/spigot/build.gradle.kts
+++ b/spigot/build.gradle.kts
@@ -23,7 +23,7 @@ tasks {
                 "name" to "MapModCompanion",
                 "version" to project.version,
                 "authors" to listOf("turikhay"),
-                "apiVersion" to "1.13",
+                "api-version" to "1.13",
                 "softDepends" to listOf("ProtocolLib"),
                 "main" to "com.turikhay.mc.mapmodcompanion.spigot.MapModCompanion",
                 "folia-supported" to true,


### PR DESCRIPTION
`[19:24:31] [Server thread/WARN]: Legacy plugin MapModCompanion v0.10.0-beta.6 does not specify an api-version.`