### PR TITLE
Fix softdepend

### DIFF
--- a/spigot/build.gradle.kts
+++ b/spigot/build.gradle.kts
@@ -24,7 +24,6 @@ tasks {
                 "version" to project.version,
                 "main" to "com.turikhay.mc.mapmodcompanion.spigot.MapModCompanion",
                 "authors" to listOf("turikhay"),
-                "website" to "https://github.com/turikhay/MapModCompanion",
                 "api-version" to "1.13",
                 "softdepend" to listOf("ProtocolLib"),
                 "folia-supported" to true,

--- a/spigot/build.gradle.kts
+++ b/spigot/build.gradle.kts
@@ -22,10 +22,10 @@ tasks {
         content.putAll(mapOf(
                 "name" to "MapModCompanion",
                 "version" to project.version,
-                "main" to "com.turikhay.mc.mapmodcompanion.spigot.MapModCompanion",
                 "authors" to listOf("turikhay"),
                 "api-version" to "1.13",
                 "softdepend" to listOf("ProtocolLib"),
+                "main" to "com.turikhay.mc.mapmodcompanion.spigot.MapModCompanion",
                 "folia-supported" to true,
         ))
     }

--- a/spigot/build.gradle.kts
+++ b/spigot/build.gradle.kts
@@ -24,6 +24,7 @@ tasks {
                 "version" to project.version,
                 "main" to "com.turikhay.mc.mapmodcompanion.spigot.MapModCompanion",
                 "authors" to listOf("turikhay"),
+                "website" to "https://github.com/turikhay/MapModCompanion",
                 "api-version" to "1.13",
                 "softdepend" to listOf("ProtocolLib"),
                 "folia-supported" to true,

--- a/spigot/build.gradle.kts
+++ b/spigot/build.gradle.kts
@@ -22,10 +22,10 @@ tasks {
         content.putAll(mapOf(
                 "name" to "MapModCompanion",
                 "version" to project.version,
+                "main" to "com.turikhay.mc.mapmodcompanion.spigot.MapModCompanion",
                 "authors" to listOf("turikhay"),
                 "api-version" to "1.13",
                 "softdepend" to listOf("ProtocolLib"),
-                "main" to "com.turikhay.mc.mapmodcompanion.spigot.MapModCompanion",
                 "folia-supported" to true,
         ))
     }

--- a/spigot/build.gradle.kts
+++ b/spigot/build.gradle.kts
@@ -24,7 +24,7 @@ tasks {
                 "version" to project.version,
                 "authors" to listOf("turikhay"),
                 "api-version" to "1.13",
-                "softDepends" to listOf("ProtocolLib"),
+                "softdepend" to listOf("ProtocolLib"),
                 "main" to "com.turikhay.mc.mapmodcompanion.spigot.MapModCompanion",
                 "folia-supported" to true,
         ))


### PR DESCRIPTION
Follow-up to #131

I wasn't paying attention to [the actual/correct field names](https://docs.papermc.io/paper/dev/plugin-yml) when I removed Spigradle support (#73): `softDepends` should be `softdepend`