### PR TITLE
Support testing on 1.20.6 - 1.21.3

### DIFF
--- a/.github/workflows/e2e_all.yml
+++ b/.github/workflows/e2e_all.yml
@@ -17,6 +17,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - 1.21.1
+          - 1.20.6
           - 1.20.4
           - 1.19.4
           - 1.18.2

--- a/.github/workflows/e2e_notable.yml
+++ b/.github/workflows/e2e_notable.yml
@@ -20,6 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - 1.21.1
           - 1.16.5
           - 1.16.3
           - 1.13.2

--- a/.github/workflows/e2e_notable.yml
+++ b/.github/workflows/e2e_notable.yml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 1.20.4
+          - 1.20.6
         proxy:
           - velocity
           - bungeecord

--- a/tests_e2e/run.py
+++ b/tests_e2e/run.py
@@ -81,7 +81,9 @@ VERSIONS = {
         ))
     ),
     **(
-        dict((version, {}) for version in (
+        dict((version, {
+            'java': 17,
+        }) for version in (
             '1.17.1',
             '1.18.2',
             '1.19.3',
@@ -95,6 +97,7 @@ VERSIONS = {
         dict((
             version,
             {
+                'java': 17,
                 'folia': True,
             },
         ) for version in (
@@ -105,9 +108,22 @@ VERSIONS = {
         dict((
             version,
             {
+                'java': 21,
+            },
+        ) for version in (
+            '1.20.6',
+            '1.21.1',
+        ))
+    ),
+    **(
+        dict((
+            version,
+            {
+                'java': 21,
                 'bot': False,
             },
         ) for version in (
+            '1.21.3',
         ))
     ),
 }
@@ -214,7 +230,7 @@ if __name__ == "__main__":
     ]
 
     debug_level = int(environ.get("DEBUG")) if environ.get("DEBUG") else 0
-    debug = debug_level or environ.get("ACTIONS_STEP_DEBUG") == "true"
+    debug = debug_level > 0
     basicConfig(
         level=DEBUG if debug else INFO
     )
@@ -286,15 +302,13 @@ if __name__ == "__main__":
         bot_container = None
         assert action not in ("test",)
 
-    if "java" in version_info:
-        server_java_version = version_info["java"]
-    else:
-        server_java_version = 17
-
     if "server" in version_info:
         server_version = version_info["server"]
     else:
         server_version = client_version
+
+    assert "java" in version_info, f"java version for {server_version} is not defined"
+    server_java_version = version_info["java"]
 
     if "world" in version_info:
         world_version = version_info["world"]
@@ -470,6 +484,7 @@ if __name__ == "__main__":
                 ] if debug else [
                     '-f',
                     'bot',
+                    *servers,
                 ])
             ],
             stdout=PIPE,

--- a/tests_e2e/run.py
+++ b/tests_e2e/run.py
@@ -109,9 +109,19 @@ VERSIONS = {
             version,
             {
                 'java': 21,
+                'folia': True,
             },
         ) for version in (
             '1.20.6',
+        ))
+    ),
+    **(
+        dict((
+            version,
+            {
+                'java': 21,
+            },
+        ) for version in (
             '1.21.1',
         ))
     ),


### PR DESCRIPTION
- Requires specifying Java version for each testable version (was defaulting to Java 17 before)
- Displays server logs alongside bot output
- Debugging is only affected by setting the debug level. Before it was set by `ACTIONS_STEP_DEBUG` env var, which was never used.

The latest release 1.21.3 is not yet supported by [node-minecraft-protocol](https://github.com/PrismarineJS/node-minecraft-protocol), so it's not tested by the bot.

No Folia support for [1.20.5](https://papermc.io/api/v2/projects/folia/versions/1.20.5), 1.21 - [1.21.3](https://papermc.io/api/v2/projects/folia/versions/1.21.3) neither.