### PR TITLE
Make server type (Paper, Folia) selectable

### DIFF
--- a/.github/workflows/e2e_all.yml
+++ b/.github/workflows/e2e_all.yml
@@ -37,10 +37,11 @@ jobs:
           - velocity
           - bungeecord
           - waterfall
-        folia:
-          - false
-          - true
+        server:
+          - paper
+          - folia
     uses: ./.github/workflows/e2e_test.yml
     with:
       proxy: ${{ matrix.proxy }}
       version: ${{ matrix.version }}
+      server: ${{ matrix.server }}

--- a/.github/workflows/e2e_notable.yml
+++ b/.github/workflows/e2e_notable.yml
@@ -44,11 +44,11 @@ jobs:
         proxy:
           - velocity
           - bungeecord
-        folia:
-          - false
-          - true
+        server:
+          - paper
+          - folia
     uses: ./.github/workflows/e2e_test.yml
     with:
       proxy: ${{ matrix.proxy }}
       version: ${{ matrix.version }}
-      folia: ${{ matrix.folia }}
+      server: ${{ matrix.server }}

--- a/.github/workflows/e2e_notable.yml
+++ b/.github/workflows/e2e_notable.yml
@@ -34,7 +34,7 @@ jobs:
       proxy: ${{ matrix.proxy }}
       version: ${{ matrix.version }}
   paper-folia:
-    name: E2E test (w/Folia)
+    name: E2E w/Folia
     needs: build
     strategy:
       fail-fast: false

--- a/.github/workflows/e2e_notable.yml
+++ b/.github/workflows/e2e_notable.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build
     uses: ./.github/workflows/nightly.yml
   paper:
-    name: E2E test
+    name: E2E
     needs: build
     strategy:
       fail-fast: false

--- a/.github/workflows/e2e_notable.yml
+++ b/.github/workflows/e2e_notable.yml
@@ -34,7 +34,7 @@ jobs:
       proxy: ${{ matrix.proxy }}
       version: ${{ matrix.version }}
   paper-folia:
-    name: E2E test (with Folia)
+    name: E2E test (w/Folia)
     needs: build
     strategy:
       fail-fast: false

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -6,15 +6,16 @@ on:
       proxy:
         required: true
         type: string
-      folia:
-          type: boolean
+      server:
+        default: paper
+        type: string
       version:
         required: true
         type: string
 
 jobs:
   test:
-    name: E2E test (${{ inputs.version }}, proxy=${{ inputs.proxy }}, folia=${{ inputs.folia }})
+    name: E2E (${{ inputs.version }}, ${{ inputs.proxy }}, ${{ inputs.server }})
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -22,7 +23,7 @@ jobs:
     env:
      # Legacy builder doesn't seem to properly mount /data folder inside server container for some reason
      DOCKER_BUILDKIT: 1
-     FOLIA: "${{ inputs.folia && '1' || '0'  }}"
+     SERVER_TYPE: "${{ inputs.server }}"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4

--- a/tests_e2e/README.md
+++ b/tests_e2e/README.md
@@ -34,4 +34,4 @@ Command:
 * `manual` – spin up specified server and proxy
 * * Use env `JAVA_DEBUG=1` to enable Java debugging. Local port `9010` goes for the proxy, `9011` for the server. Example: `JAVA_DEBUG=1 ./run.sh waterfall 1.16.5 manual`
 * * Use env `BLUE=1` to enable second server (e.g. to debug map persistence). You'll be able to switch between servers with `/server red/blue`.
-
+* * Use Env `SERVER_TYPE=folia` if you want to use Folia as a backend Minecraft server. Note that the script will just exit if there is no Folia support for the selected version.

--- a/tests_e2e/run.py
+++ b/tests_e2e/run.py
@@ -257,18 +257,20 @@ if __name__ == "__main__":
         if enable_blue:
             logger.info("Use 127.0.0.1:9011 for blue server")
 
-    enable_folia = environ.get("FOLIA") == "1"
+    server_type = environ.get("SERVER_TYPE")
+    if not server_type:
+        server_type = "paper"
 
     proxy_type, client_version, action = argv[1:]
 
     version_info = VERSIONS[client_version]
 
-    if enable_folia and ("folia" not in version_info or not version_info["folia"]):
+    if server_type == 'folia' and ("folia" not in version_info or not version_info["folia"]):
         logger.info(f"Skipping: Folia is not supported on this version ({client_version})")
         exit(0)
 
     test_name_suffix = ""
-    if enable_folia:
+    if server_type == 'folia':
         test_name_suffix += "folia_"
     test_name_suffix += f"{proxy_type}_{client_version}"
 
@@ -325,14 +327,12 @@ if __name__ == "__main__":
     else:
         world_version = "1.17.1"
 
-    if enable_folia:
-        server_type = "FOLIA"
+    if server_type in ("folia"):
         paper_channel = "experimental"
     else:
-        server_type = "PAPER"
         paper_channel = None
 
-    logger.info(f"Selected server type: {server_type}")
+    logger.info(f"Server type: {server_type}")
 
     for server_name in servers:
         server_desc = {
@@ -347,7 +347,7 @@ if __name__ == "__main__":
             },
             'environment': [
                 f'VERSION={server_version}',
-                f'TYPE={server_type}',
+                f'TYPE={server_type.upper()}',
                 *([
                     f'PAPER_CHANNEL={paper_channel}',
                 ] if paper_channel else []),


### PR DESCRIPTION
docker-minecraft-server supports [different backend servers](https://docker-minecraft-server.readthedocs.io/en/latest/types-and-platforms/server-types/paper/).
This PR makes it easier to select between these. It's also making GitHub Actions look cleaner: there are no more ambiguous `false` and `true` action variants.