### PR TITLE
Ignore dependency-graph-reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ bin/
 ### Python ###
 /venv/
 /.venv/
+
+### GitHub Gradle Actions ###
+dependency-graph-reports/


### PR DESCRIPTION
create-pull-requests creates invalid PRs (#170, #171) because Gradle dependency graph files are not ignored