### PR TITLE
Upgrade ProtocolLib to 5.3.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,8 +53,7 @@ jobs:
           ./gradlew \
           ${{ inputs.task }} \
           -Pversion=${{ inputs.version }} \
-          -Pspigot_version=${{ steps.target.outputs.spigot-version }} \
-          -PprotocolLib_version=4.2.1
+          -Pspigot_version=${{ steps.target.outputs.spigot-version }}
         env:
           HANGAR_TOKEN: ${{ secrets.hangar-token }}
           MODRINTH_TOKEN: ${{ secrets.modrinth-token }}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 group=com.turikhay.mc
 version=0.0.0-SNAPSHOT
 spigot_version=1.20.1
-protocolLib_version=4.7.0
+protocolLib_version=5.3.0


### PR DESCRIPTION
This project relied on the oldest available version of ProtocolLib. However, since all 4.x.x versions have been removed from dmulloy2's repository (see https://github.com/dmulloy2/ProtocolLib/issues/3528), I'm updating it to version 5.3.0. This version seems to be backwards compatible for our needs.

For testing Minecraft versions 1.13.2 to 1.16.3, we'll keep using older [ProtocolLib 4.8.0](https://github.com/dmulloy2/ProtocolLib/releases/download/4.8.0/ProtocolLib.jar).