### PR TITLE
Fix watchdog firing multiple times after single file change

### DIFF
--- a/common/src/main/java/com/turikhay/mc/mapmodcompanion/FileChangeWatchdog.java
+++ b/common/src/main/java/com/turikhay/mc/mapmodcompanion/FileChangeWatchdog.java
@@ -50,6 +50,7 @@ public class FileChangeWatchdog implements Disposable {
             return;
         }
         if (!time.equals(lastTime)) {
+            lastTime = time;
             logger.info("File has been changed: " + path);
             try {
                 callback.run();

--- a/common/src/test/java/FileChangeWatchdogTest.java
+++ b/common/src/test/java/FileChangeWatchdogTest.java
@@ -1,0 +1,45 @@
+import com.turikhay.mc.mapmodcompanion.FileChangeWatchdog;
+import com.turikhay.mc.mapmodcompanion.ILogger;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class FileChangeWatchdogTest {
+
+    @Test
+    void callbackRunsOnceWhenFileChanges() throws Exception {
+        Path file = Files.createTempFile("watchdog", ".tmp");
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        try {
+            AtomicInteger counter = new AtomicInteger();
+            FileChangeWatchdog watchdog = new FileChangeWatchdog(
+                    ILogger.ofJava(java.util.logging.Logger.getAnonymousLogger()),
+                    scheduler,
+                    file,
+                    counter::incrementAndGet
+            );
+            Method tick = FileChangeWatchdog.class.getDeclaredMethod("tick");
+            tick.setAccessible(true);
+
+            tick.invoke(watchdog); // initialize lastTime
+
+            Thread.sleep(1000);
+            Files.writeString(file, "a");
+
+            tick.invoke(watchdog); // should trigger callback
+            tick.invoke(watchdog); // should not trigger again
+
+            assertEquals(1, counter.get());
+        } finally {
+            scheduler.shutdownNow();
+            Files.deleteIfExists(file);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- update FileChangeWatchdog to remember last modification time after triggering
- test that callback runs only once per file change

## Testing
- `./gradlew :common:test`


------
https://chatgpt.com/codex/tasks/task_e_68966c4886888328bc7fa562d87b7778