### PR TITLE
Clarify level map properties packet error messages

### DIFF
--- a/common/src/main/java/com/turikhay/mc/mapmodcompanion/LevelMapProperties.java
+++ b/common/src/main/java/com/turikhay/mc/mapmodcompanion/LevelMapProperties.java
@@ -14,9 +14,9 @@ public interface LevelMapProperties {
                 if (marker == 0) {
                     return new StandardId(in.readInt());
                 }
-                throw new MalformedPacketException("invalid marker byte (0x" + Integer.toHexString(marker) + ") in the standard id packet");
+                throw new MalformedPacketException("invalid marker byte (0x" + Integer.toHexString(marker) + ") in the level map properties packet");
             } catch (IOException e) {
-                throw new MalformedPacketException("unexpected error reading standard id packet", e);
+                throw new MalformedPacketException("unexpected error reading level map properties packet", e);
             }
         }
 


### PR DESCRIPTION
## Summary
- Replace outdated "standard id packet" wording in level map properties deserializer
- Ensure consistent terminology in error handling

## Testing
- `./gradlew :common:test`


------
https://chatgpt.com/codex/tasks/task_e_68966e55c4388328831e3e75926330e5