### PR TITLE
Add test for zero-filled PrefixedId packets

### DIFF
--- a/common/src/test/java/PrefixedIdPacketDeserializerTest.java
+++ b/common/src/test/java/PrefixedIdPacketDeserializerTest.java
@@ -24,6 +24,12 @@ class PrefixedIdPacketDeserializerTest {
         test(new PrefixedId(0, true, 1), new byte[] { 42, 1, 49 });
     }
 
+    @Test
+    void zeroFilledArrayTest() {
+        assertThrows(MalformedPacketException.class,
+                () -> deserializer.deserialize(new byte[] { 0, 0, 0 }));
+    }
+
     private void test(PrefixedId expected, byte[] data) throws MalformedPacketException {
         assertEquals(expected, deserializer.deserialize(data));
     }


### PR DESCRIPTION
## Summary
- add a regression test ensuring a zero-filled packet triggers `MalformedPacketException`

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68966e64d2488328a2d291fcfa4e238b