### PR TITLE
Fix BungeeCord spelling in E2E tests README

### DIFF
--- a/tests_e2e/README.md
+++ b/tests_e2e/README.md
@@ -8,7 +8,7 @@ $ free -h
 
 ## Why?
 
-I wanted to verify if the plugin actually works on all Minecraft versions we claim it supports. Setting up 30+ Paper, Bungeecord and Velocity instances manually was just too much work for me.
+I wanted to verify if the plugin actually works on all Minecraft versions we claim it supports. Setting up 30+ Paper, BungeeCord and Velocity instances manually was just too much work for me.
 
 ## How?
 


### PR DESCRIPTION
## Summary
- fix improper BungeeCord capitalization in E2E test docs
- keep proxy argument names lowercase

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68966e6bf3c083289a7d2f8540282b89