### PR TITLE
Use ProtocolLib from Maven Central

### DIFF
--- a/spigot/build.gradle.kts
+++ b/spigot/build.gradle.kts
@@ -40,5 +40,5 @@ dependencies {
 
     // These dependencies are intentionally not present in libs.version.toml
     compileOnly("org.spigotmc:spigot-api:${spigot_version}-R0.1-SNAPSHOT")
-    compileOnly("com.comphenix.protocol:ProtocolLib:${protocolLib_version}")
+    compileOnly("net.dmulloy2:ProtocolLib:${protocolLib_version}")
 }

--- a/spigot/build.gradle.kts
+++ b/spigot/build.gradle.kts
@@ -4,10 +4,6 @@ plugins {
 
 repositories {
     maven {
-        name = "ProtocolLib"
-        url = uri("https://repo.dmulloy2.net/repository/public/")
-    }
-    maven {
         name = "Sonatype"
         url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
     }


### PR DESCRIPTION
Related to #203
See https://github.com/dmulloy2/ProtocolLib/issues/3373

[Recent builds](https://github.com/turikhay/MapModCompanion/actions/runs/17378639437/job/49330666057) have been failing with this error:
```
    > Could not resolve com.comphenix.protocol:ProtocolLib:5.3.0.
     Required by:
         project ':spigot'
      > Could not resolve com.comphenix.protocol:ProtocolLib:5.3.0.
         > Could not get resource 'https://repo.dmulloy2.net/repository/public/com/comphenix/protocol/ProtocolLib/5.3.0/ProtocolLib-5.3.0.pom'.
            > Could not GET 'https://repo.dmulloy2.net/repository/public/com/comphenix/protocol/ProtocolLib/5.3.0/ProtocolLib-5.3.0.pom'. Received status code 403 from server: Forbidden
```

Since ProtocolLib is now published on Maven Central under a new group ID (`net.dmulloy2` instead of `com.comphenix.protocol`, see https://github.com/dmulloy2/ProtocolLib/issues/3528), it's easier to just switch to it instead.