### PR TITLE
Fix ConcurrentModificationException in CacheableRegistry on Folia/CanvasMC servers

### DIFF
--- a/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/IdRegistry.java
+++ b/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/IdRegistry.java
@@ -5,16 +5,16 @@ import com.turikhay.mc.mapmodcompanion.PrefixLogger;
 import com.turikhay.mc.mapmodcompanion.VerboseLogger;
 import org.bukkit.World;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 
 public interface IdRegistry {
     int getId(World world);
 
     class CacheableRegistry implements IdRegistry {
-        private final Map<String, Integer> cache = new HashMap<>();
+        private final Map<String, Integer> cache = new ConcurrentHashMap<>();
         private final IdRegistry delegate;
 
         public CacheableRegistry(IdRegistry delegate) {


### PR DESCRIPTION
## Problem

When players join a Folia or CanvasMC server, a `ConcurrentModificationException` is thrown in `CacheableRegistry.getId()`:

```
java.util.ConcurrentModificationException
    at java.base/java.util.HashMap.computeIfAbsent(HashMap.java:1230)
    at MapModCompanion.jar//...spigot.IdRegistry$CacheableRegistry.getId(IdRegistry.java:26)
    at MapModCompanion.jar//...spigot.XaeroHandler.sendPacket(XaeroHandler.java:67)
    at MapModCompanion.jar//...spigot.XaeroHandler.onPlayerJoined(XaeroHandler.java:56)
```

Folia (and forks like CanvasMC) uses regionized multithreading, meaning `PlayerJoinEvent` can be fired concurrently from different region tick threads. The `CacheableRegistry` cache was backed by a plain `HashMap`, which is **not** thread-safe. Concurrent calls to `HashMap.computeIfAbsent()` from multiple threads cause a `ConcurrentModificationException`.

Full log: https://mclo.gs/bYg8IkD

## Fix

Replace `HashMap` with `ConcurrentHashMap` in `CacheableRegistry`:

```diff
- private final Map<String, Integer> cache = new HashMap<>();
+ private final Map<String, Integer> cache = new ConcurrentHashMap<>();
```

`ConcurrentHashMap.computeIfAbsent()` is atomic and thread-safe, which prevents the concurrent modification issue on multi-threaded server implementations.

## Impact

- Fixes exception on player join for **Folia**, **CanvasMC**, and other regionized server forks.
- No behavioral change on standard Spigot/Paper servers (single-threaded tick loop).