### PR TITLE
Avoiding manual task creation

### DIFF
--- a/buildSrc/src/main/kotlin/PluginDescriptor.kt
+++ b/buildSrc/src/main/kotlin/PluginDescriptor.kt
@@ -35,12 +35,6 @@ abstract class PluginDescriptorTask : DefaultTask() {
     @get:Optional
     abstract val append: Property<Boolean>
 
-    init {
-        project.tasks.getByName("processResources") {
-            finalizedBy(this@PluginDescriptorTask)
-        }
-    }
-
     @TaskAction
     fun writeFile() {
         val mapper = constructMapper()

--- a/bungee/build.gradle.kts
+++ b/bungee/build.gradle.kts
@@ -26,6 +26,9 @@ tasks {
                 "main" to "com.turikhay.mc.mapmodcompanion.bungee.MapModCompanion"
         ))
     }
+    processResources {
+        finalizedBy(writeBungeeYml)
+    }
 }
 
 dependencies {

--- a/bungee/build.gradle.kts
+++ b/bungee/build.gradle.kts
@@ -17,7 +17,7 @@ repositories {
 }
 
 tasks {
-    val writeBungeeYml by creating(PluginDescriptorTask::class) {
+    val writeBungeeYml by registering(PluginDescriptorTask::class) {
         descriptor = "bungee.yml"
         content.putAll(mapOf(
                 "name" to "MapModCompanion",

--- a/spigot/build.gradle.kts
+++ b/spigot/build.gradle.kts
@@ -14,7 +14,7 @@ repositories {
 }
 
 tasks {
-    val writePluginYml by creating(PluginDescriptorTask::class) {
+    val writePluginYml by registering(PluginDescriptorTask::class) {
         descriptor = "plugin.yml"
         content.putAll(mapOf(
                 "name" to "MapModCompanion",

--- a/spigot/build.gradle.kts
+++ b/spigot/build.gradle.kts
@@ -28,6 +28,9 @@ tasks {
                 "folia-supported" to true,
         ))
     }
+    processResources {
+        finalizedBy(writePluginYml)
+    }
 }
 
 // From gradle.properties

--- a/velocity/build.gradle.kts
+++ b/velocity/build.gradle.kts
@@ -32,4 +32,7 @@ tasks {
                 "version" to project.version
         ))
     }
+    processResources {
+        finalizedBy(rewriteVelocityPluginJson)
+    }
 }

--- a/velocity/build.gradle.kts
+++ b/velocity/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
 }
 
 tasks {
-    val rewriteVelocityPluginJson by creating(PluginDescriptorTask::class) {
+    val rewriteVelocityPluginJson by registering(PluginDescriptorTask::class) {
         dependsOn(compileJava)
         descriptorFile = project.layout.buildDirectory.file("classes/java/main/velocity-plugin.json")
         format = PluginDescriptorFormat.JSON


### PR DESCRIPTION
```
> Configure project :bungee
w: file:///home/turikhay/projects/MapModCompanion/bungee/build.gradle.kts:20:27: 'fun <U : Task> TaskContainer.creating(type: KClass<U>, configuration: U.() -> Unit): PolymorphicDomainObjectContainerCreatingDelegateProvider<Task, U>' is deprecated. Use registering instead. See https://docs.gradle.org/current/userguide/task_configuration_avoidance.html for more information.

> Configure project :spigot
w: file:///home/turikhay/projects/MapModCompanion/spigot/build.gradle.kts:17:27: 'fun <U : Task> TaskContainer.creating(type: KClass<U>, configuration: U.() -> Unit): PolymorphicDomainObjectContainerCreatingDelegateProvider<Task, U>' is deprecated. Use registering instead. See https://docs.gradle.org/current/userguide/task_configuration_avoidance.html for more information.

> Configure project :velocity
w: file:///home/turikhay/projects/MapModCompanion/velocity/build.gradle.kts:26:38: 'fun <U : Task> TaskContainer.creating(type: KClass<U>, configuration: U.() -> Unit): PolymorphicDomainObjectContainerCreatingDelegateProvider<Task, U>' is deprecated. Use registering instead. See https://docs.gradle.org/current/userguide/task_configuration_avoidance.html for more information.
```