### PR TITLE
Listen to respawn packets with PacketEvents

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ If you have any questions, please [join my Discord][Discord].
 | [JourneyMap]        | v5.7.1 / Minecraft 1.16.5                 | v6.0.0-beta.78 / Minecraft 26.1.2              | ✅ Supported                                                                                         |
 | VoxelMap            | [v1.7.10][VoxelMap (old)] / Minecraft 1.8 | [v1.16.6][VoxelMap-Updated] / Minecraft 26.1.2 | ✅ Supported<sup class="reference">[[2]](https://github.com/turikhay/MapModCompanion/issues/8)</sup> |
 
-[Folia](https://papermc.io/software/folia) is supported and needs [PacketEvents](https://modrinth.com/plugin/packetevents/versions?l=folia) to work properly<sup class="reference">[[3]](https://github.com/turikhay/MapModCompanion/pull/251)</sup>. Please report if the support is broken.
+[Folia](https://papermc.io/software/folia) is supported and needs [PacketEvents](https://modrinth.com/plugin/packetevents/versions?l=folia) to work properly<sup class="reference">[[3]](https://github.com/turikhay/MapModCompanion/pull/251)</sup>. Please report if support is broken.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ If you have any questions, please [join my Discord][Discord].
 
 ## Installation
 
-ℹ️ Plugin must be installed on every downstream (backend) server in your network. Simply installing it on the proxy side (BungeeCord/Velocity) isn't enough. To ensure compatibility, you need to install the plugin on both the proxy server (BungeeCord/Velocity) and each of the backend servers (Spigot/Paper).
+ℹ️ Plugin must be installed on every downstream (backend) server in your network. Simply installing it on the proxy side (BungeeCord/Velocity) isn't enough. To ensure compatibility, you need to install the plugin on both the proxy server (BungeeCord/Velocity) and each of the backend servers (Spigot/Paper/Folia).
 
 1. Download the latest release
 2. Put each file into the corresponding plugins folder

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ If you have any questions, please [join my Discord][Discord].
 | [JourneyMap]        | v5.7.1 / Minecraft 1.16.5                 | v6.0.0-beta.78 / Minecraft 26.1.2              | ✅ Supported                                                                                         |
 | VoxelMap            | [v1.7.10][VoxelMap (old)] / Minecraft 1.8 | [v1.16.6][VoxelMap-Updated] / Minecraft 26.1.2 | ✅ Supported<sup class="reference">[[2]](https://github.com/turikhay/MapModCompanion/issues/8)</sup> |
 
-[Folia](https://papermc.io/software/folia) is supported, but isn't tested thoroughly. Please report if the support is broken.
+[Folia](https://papermc.io/software/folia) is supported and needs [PacketEvents](https://modrinth.com/plugin/packetevents/versions?l=folia) to work properly<sup class="reference">[[3]](https://github.com/turikhay/MapModCompanion/pull/251)</sup>. Please report if the support is broken.
 
 ## Installation
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,4 @@ group=com.turikhay.mc
 version=0.0.0-SNAPSHOT
 spigot_version=1.20.1
 protocolLib_version=5.3.0
+packetEvents_version=2.12.1

--- a/spigot/build.gradle.kts
+++ b/spigot/build.gradle.kts
@@ -11,6 +11,10 @@ repositories {
         name = "Spigot"
         url = uri("https://hub.spigotmc.org/nexus/content/repositories/public/")
     }
+    maven {
+        name = "CodeMC"
+        url = uri("https://repo.codemc.io/repository/maven-releases/")
+    }
 }
 
 tasks {
@@ -24,7 +28,7 @@ tasks {
                 "authors" to listOf("turikhay"),
                 "website" to "https://github.com/turikhay/MapModCompanion",
                 "api-version" to "1.13",
-                "softdepend" to listOf("ProtocolLib"),
+                "softdepend" to listOf("ProtocolLib", "packetevents"),
                 "folia-supported" to true,
         ))
     }
@@ -36,6 +40,7 @@ tasks {
 // From gradle.properties
 val spigot_version: String by project
 val protocolLib_version: String by project
+val packetEvents_version: String by project
 
 dependencies {
     implementation(project(":common"))
@@ -44,4 +49,5 @@ dependencies {
     // These dependencies are intentionally not present in libs.version.toml
     compileOnly("org.spigotmc:spigot-api:${spigot_version}-R0.1-SNAPSHOT")
     compileOnly("net.dmulloy2:ProtocolLib:${protocolLib_version}")
+    compileOnly("com.github.retrooper:packetevents-spigot:${packetEvents_version}")
 }

--- a/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroHandler.java
+++ b/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroHandler.java
@@ -2,31 +2,32 @@ package com.turikhay.mc.mapmodcompanion.spigot;
 
 import com.turikhay.mc.mapmodcompanion.*;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Supplier;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class XaeroHandler implements Handler {
     private final ScheduledExecutorService scheduler;
-    private final XaeroSpigotListener listener;
+    private final List<XaeroListener> listeners;
 
-    public XaeroHandler(Logger logger, String configPath, String channelName, MapModCompanion plugin) {
-        this.scheduler = Executors.newSingleThreadScheduledExecutor(
-                new DaemonThreadFactory(ILogger.ofJava(logger), XaeroHandler.class)
-        );
-        this.listener = new XaeroSpigotListener(logger, plugin, channelName,
-                new XaeroLevelMapSender(logger, plugin, channelName, configPath, scheduler)
-        );
-    }
-
-    public void init() throws InitializationException {
-        listener.init();
+    public XaeroHandler(ScheduledExecutorService scheduler, List<XaeroListener> listeners) {
+        this.scheduler = scheduler;
+        this.listeners = listeners;
     }
 
     @Override
     public void cleanUp() {
-        listener.cleanUp();
-        scheduler.shutdown();
+        try {
+            listeners.forEach(Disposable::cleanUp);
+        } finally {
+            scheduler.shutdown();
+        }
     }
 
     public static class Factory implements Handler.Factory<MapModCompanion> {
@@ -46,14 +47,61 @@ public class XaeroHandler implements Handler {
         @Override
         public XaeroHandler create(MapModCompanion plugin) throws InitializationException {
             plugin.checkEnabled(configPath);
-            XaeroHandler handler = new XaeroHandler(
-                    new PrefixLogger(plugin.getVerboseLogger(), channelName),
-                    configPath, channelName, plugin
+            PrefixLogger logger = new PrefixLogger(plugin.getVerboseLogger(), channelName);
+            ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(
+                    new DaemonThreadFactory(ILogger.ofJava(logger), XaeroHandler.class)
             );
-            handler.init();
-            return handler;
+            ListenerFactory factory = new ListenerFactory(
+                    plugin,
+                    logger,
+                    new XaeroLevelMapSender(logger, plugin, channelName, configPath, scheduler)
+            );
+            List<Supplier<XaeroListener>> candidates = factory.getCandidateFactories();
+            List<XaeroListener> listeners = new ArrayList<>(candidates.size());
+            Set<String> neighbors = new HashSet<>(candidates.size());
+            List<Throwable> suppressed = new ArrayList<>(candidates.size());
+            for (Supplier<XaeroListener> cf : candidates) {
+                XaeroListener listener;
+                try {
+                    listener = cf.get();
+                    listener.init(neighbors);
+                } catch (Throwable t) {
+                    logger.log(Level.WARNING, "Failed to create or initialize a listener", t);
+                    suppressed.add(t);
+                    continue;
+                }
+                neighbors.add(listener.name());
+                listeners.add(listener);
+            }
+            if (listeners.isEmpty()) {
+                InitializationException e = new InitializationException("Failed to create at least one of listeners; check suppressed exceptions");
+                suppressed.forEach(e::addSuppressed);
+                throw e;
+            }
+            logger.info("Created listeners: " + listeners);
+            return new XaeroHandler(scheduler, listeners);
+        }
+
+        private class ListenerFactory {
+            final MapModCompanion plugin;
+            final Logger logger;
+            final XaeroLevelMapSender sender;
+
+            private ListenerFactory(MapModCompanion plugin, Logger logger, XaeroLevelMapSender sender) {
+                this.plugin = plugin;
+                this.logger = logger;
+                this.sender = sender;
+            }
+
+            public List<Supplier<XaeroListener>> getCandidateFactories() {
+                List<Supplier<XaeroListener>> listeners = new ArrayList<>();
+                listeners.add(this::createSpigotListener);
+                return listeners;
+            }
+
+            XaeroListener createSpigotListener() {
+                return new XaeroSpigotListener(logger, plugin, channelName, sender);
+            }
         }
     }
-
-
 }

--- a/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroHandler.java
+++ b/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroHandler.java
@@ -66,16 +66,16 @@ public class XaeroHandler implements Handler {
                     listener.init(neighbors);
                 } catch (Throwable t) {
                     if (t instanceof InitializationException) {
-                        logger.log(Level.INFO, "One of the listeners will not be available: " + t.getMessage());
+                        logger.log(Level.INFO, candidate.getName() + " listener will not be available: " + t.getMessage());
                     } else {
-                        logger.log(Level.WARNING, "Failed to create or initialize a listener", t);
+                        logger.log(Level.WARNING, "Failed to create or initialize " + candidate.getName() + " listener", t);
                     }
                     suppressed.add(t);
                     continue;
                 }
-                neighbors.add(listener.name());
+                neighbors.add(candidate.getName());
                 listeners.add(listener);
-                logger.fine("Listener created: " + listener.name());
+                logger.fine(candidate.getName() + " listener created (" + listener + ")");
             }
             if (listeners.isEmpty()) {
                 InitializationException e = new InitializationException("Failed to create at least one of listeners; check suppressed exceptions");
@@ -99,8 +99,8 @@ public class XaeroHandler implements Handler {
 
             public List<Candidate> getCandidateFactories() {
                 List<Candidate> listeners = new ArrayList<>();
-                listeners.add(this::createPacketEventsListener);
-                listeners.add(this::createSpigotListener);
+                listeners.add(new Candidate(XaeroRespawnPacketListener.NAME, this::createPacketEventsListener));
+                listeners.add(new Candidate(XaeroSpigotListener.NAME, this::createSpigotListener));
                 return listeners;
             }
 
@@ -123,8 +123,27 @@ public class XaeroHandler implements Handler {
             }
         }
 
-        private interface Candidate {
+        private interface CandidateFn {
             XaeroListener create() throws InitializationException;
+        }
+
+        private static class Candidate implements CandidateFn {
+            private final String name;
+            private final CandidateFn fn;
+
+            private Candidate(String name, CandidateFn fn) {
+                this.name = name;
+                this.fn = fn;
+            }
+
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public XaeroListener create() throws InitializationException {
+                return fn.create();
+            }
         }
     }
 }

--- a/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroHandler.java
+++ b/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroHandler.java
@@ -67,7 +67,7 @@ public class XaeroHandler implements Handler {
                     listener.init(neighbors);
                 } catch (Throwable t) {
                     if (t instanceof InitializationException) {
-                        logger.log(Level.INFO, "Listener is not available: " + t.getMessage());
+                        logger.log(Level.INFO, "One of the listeners will not be available: " + t.getMessage());
                     } else {
                         logger.log(Level.WARNING, "Failed to create or initialize a listener", t);
                     }

--- a/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroHandler.java
+++ b/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroHandler.java
@@ -56,22 +56,27 @@ public class XaeroHandler implements Handler {
                     logger,
                     new XaeroLevelMapSender(logger, plugin, channelName, configPath, scheduler)
             );
-            List<Supplier<XaeroListener>> candidates = factory.getCandidateFactories();
+            List<Candidate> candidates = factory.getCandidateFactories();
             List<XaeroListener> listeners = new ArrayList<>(candidates.size());
             Set<String> neighbors = new HashSet<>(candidates.size());
             List<Throwable> suppressed = new ArrayList<>(candidates.size());
-            for (Supplier<XaeroListener> cf : candidates) {
+            for (Candidate candidate : candidates) {
                 XaeroListener listener;
                 try {
-                    listener = cf.get();
+                    listener = candidate.create();
                     listener.init(neighbors);
                 } catch (Throwable t) {
-                    logger.log(Level.WARNING, "Failed to create or initialize a listener", t);
+                    if (t instanceof InitializationException) {
+                        logger.log(Level.INFO, "Listener is not available: " + t);
+                    } else {
+                        logger.log(Level.WARNING, "Failed to create or initialize a listener", t);
+                    }
                     suppressed.add(t);
                     continue;
                 }
                 neighbors.add(listener.name());
                 listeners.add(listener);
+                logger.fine("Listener created: " + listener.name());
             }
             if (listeners.isEmpty()) {
                 InitializationException e = new InitializationException("Failed to create at least one of listeners; check suppressed exceptions");
@@ -93,20 +98,34 @@ public class XaeroHandler implements Handler {
                 this.sender = sender;
             }
 
-            public List<Supplier<XaeroListener>> getCandidateFactories() {
-                List<Supplier<XaeroListener>> listeners = new ArrayList<>();
+            public List<Candidate> getCandidateFactories() {
+                List<Candidate> listeners = new ArrayList<>();
                 listeners.add(this::createPacketEventsListener);
                 listeners.add(this::createSpigotListener);
                 return listeners;
             }
 
-            XaeroListener createPacketEventsListener() throws NoClassDefFoundError {
-                return new XaeroRespawnPacketListener(sender);
+            XaeroListener createPacketEventsListener() throws InitializationException {
+                try {
+                    return new XaeroRespawnPacketListener(sender);
+                } catch (NoClassDefFoundError e) {
+                    if (FoliaSupport.isFoliaServer()) {
+                        logger.log(Level.WARNING, "PacketEvents is not found. Please install it, if it's available for your Folia version.");
+                        logger.log(Level.WARNING, "While it is not required, it is strongly advised to have it in your plugins folder.");
+                        logger.log(Level.WARNING, "For more info, see: https://github.com/turikhay/MapModCompanion/issues/224");
+                        logger.log(Level.WARNING, "We'll print the stack trace for your attention :)", e);
+                    }
+                    throw new InitializationException("PacketEvents is not found", e);
+                }
             }
 
             XaeroListener createSpigotListener() {
                 return new XaeroSpigotListener(logger, plugin, channelName, sender);
             }
+        }
+
+        private interface Candidate {
+            XaeroListener create() throws InitializationException;
         }
     }
 }

--- a/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroHandler.java
+++ b/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroHandler.java
@@ -1,8 +1,6 @@
 package com.turikhay.mc.mapmodcompanion.spigot;
 
 import com.turikhay.mc.mapmodcompanion.*;
-import org.bukkit.World;
-import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.HandlerList;
@@ -11,30 +9,26 @@ import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.bukkit.event.player.PlayerEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 
-import java.util.Arrays;
-import java.util.Locale;
-import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 public class XaeroHandler implements Handler, Listener {
     private final Logger logger;
-    private final String configPath;
     private final String channelName;
     private final MapModCompanion plugin;
     private final ScheduledExecutorService scheduler;
+    private final XaeroLevelMapSender sender;
 
     public XaeroHandler(Logger logger, String configPath, String channelName, MapModCompanion plugin) {
         this.logger = logger;
-        this.configPath = configPath;
         this.channelName = channelName;
         this.plugin = plugin;
 
         this.scheduler = Executors.newSingleThreadScheduledExecutor(
                 new DaemonThreadFactory(ILogger.ofJava(logger), XaeroHandler.class)
         );
+        this.sender = new XaeroLevelMapSender(logger, plugin, channelName, configPath, scheduler);
     }
 
     public void init() throws InitializationException {
@@ -53,36 +47,16 @@ public class XaeroHandler implements Handler, Listener {
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerJoined(PlayerJoinEvent event) {
-        sendPacket(event, Type.JOIN);
+        sendPacket(event, XaeroLevelMapSender.EventSource.JOIN);
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onWorldChanged(PlayerChangedWorldEvent event) {
-        sendPacket(event, Type.WORLD_CHANGE);
+        sendPacket(event, XaeroLevelMapSender.EventSource.WORLD_CHANGE);
     }
 
-    private void sendPacket(PlayerEvent event, Type type) {
-        Player p = event.getPlayer();
-        World world = p.getWorld();
-        int id = plugin.getRegistry().getId(world);
-        byte[] payload = LevelMapProperties.Serializer.instance().serialize(id);
-        SendPayloadTask task = new SendPayloadTask(logger, plugin, p.getUniqueId(), channelName, payload, world.getUID());
-        int repeatTimes = plugin.getConfig().getInt(
-                configPath + ".events." + type.name().toLowerCase(Locale.ROOT) + ".repeat_times",
-                1
-        );
-        if (repeatTimes > 1) {
-            for (int i = 0; i < repeatTimes; i++) {
-                scheduler.schedule(task, i, TimeUnit.SECONDS);
-            }
-        } else {
-            task.run();
-        }
-    }
-
-    private enum Type {
-        JOIN,
-        WORLD_CHANGE,
+    private void sendPacket(PlayerEvent event, XaeroLevelMapSender.EventSource source) {
+        sender.sendPacket(event.getPlayer(), source);
     }
 
     public static class Factory implements Handler.Factory<MapModCompanion> {
@@ -111,37 +85,5 @@ public class XaeroHandler implements Handler, Listener {
         }
     }
 
-    private static class SendPayloadTask implements Runnable {
-        private final Logger logger;
-        private final MapModCompanion plugin;
-        private final UUID playerId;
-        private final String channelName;
-        private final byte[] payload;
-        private final UUID expectedWorld;
 
-        public SendPayloadTask(Logger logger, MapModCompanion plugin, UUID playerId, String channelName, byte[] payload,
-                               UUID expectedWorld) {
-            this.logger = logger;
-            this.plugin = plugin;
-            this.playerId = playerId;
-            this.channelName = channelName;
-            this.payload = payload;
-            this.expectedWorld = expectedWorld;
-        }
-
-        @Override
-        public void run() {
-            Player player = plugin.getServer().getPlayer(playerId);
-            if (player == null) {
-                return;
-            }
-            UUID world = player.getWorld().getUID();
-            if (!world.equals(expectedWorld)) {
-                logger.fine("Skipping sending Xaero's LevelMapProperties to " + player.getName() + ": unexpected world");
-                return;
-            }
-            logger.fine(() -> "Sending Xaero's LevelMapProperties to " + player.getName() + ": " + Arrays.toString(payload));
-            player.sendPluginMessage(plugin, channelName, payload);
-        }
-    }
 }

--- a/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroHandler.java
+++ b/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroHandler.java
@@ -111,7 +111,7 @@ public class XaeroHandler implements Handler {
                     if (FoliaSupport.isFoliaServer()) {
                         logger.log(Level.WARNING, "PacketEvents is not found. Please install it, if it's available for your Folia version.");
                         logger.log(Level.WARNING, "While it is not required, it is strongly advised to have it in your plugins folder.");
-                        logger.log(Level.WARNING, "For more info, see: https://github.com/turikhay/MapModCompanion/issues/224");
+                        logger.log(Level.WARNING, "For more info, see: https://github.com/turikhay/MapModCompanion/pull/251");
                         logger.log(Level.WARNING, "We'll print the stack trace for your attention :)", e);
                     }
                     throw new InitializationException("PacketEvents is not found", e);

--- a/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroHandler.java
+++ b/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroHandler.java
@@ -67,7 +67,7 @@ public class XaeroHandler implements Handler {
                     listener.init(neighbors);
                 } catch (Throwable t) {
                     if (t instanceof InitializationException) {
-                        logger.log(Level.INFO, "Listener is not available: " + t);
+                        logger.log(Level.INFO, "Listener is not available: " + t.getMessage());
                     } else {
                         logger.log(Level.WARNING, "Failed to create or initialize a listener", t);
                     }

--- a/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroHandler.java
+++ b/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroHandler.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 

--- a/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroHandler.java
+++ b/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroHandler.java
@@ -95,8 +95,13 @@ public class XaeroHandler implements Handler {
 
             public List<Supplier<XaeroListener>> getCandidateFactories() {
                 List<Supplier<XaeroListener>> listeners = new ArrayList<>();
+                listeners.add(this::createPacketEventsListener);
                 listeners.add(this::createSpigotListener);
                 return listeners;
+            }
+
+            XaeroListener createPacketEventsListener() throws NoClassDefFoundError {
+                return new XaeroRespawnPacketListener(sender);
             }
 
             XaeroListener createSpigotListener() {

--- a/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroHandler.java
+++ b/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroHandler.java
@@ -1,62 +1,32 @@
 package com.turikhay.mc.mapmodcompanion.spigot;
 
 import com.turikhay.mc.mapmodcompanion.*;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.EventPriority;
-import org.bukkit.event.HandlerList;
-import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerChangedWorldEvent;
-import org.bukkit.event.player.PlayerEvent;
-import org.bukkit.event.player.PlayerJoinEvent;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.logging.Logger;
 
-public class XaeroHandler implements Handler, Listener {
-    private final Logger logger;
-    private final String channelName;
-    private final MapModCompanion plugin;
+public class XaeroHandler implements Handler {
     private final ScheduledExecutorService scheduler;
-    private final XaeroLevelMapSender sender;
+    private final XaeroSpigotListener listener;
 
     public XaeroHandler(Logger logger, String configPath, String channelName, MapModCompanion plugin) {
-        this.logger = logger;
-        this.channelName = channelName;
-        this.plugin = plugin;
-
         this.scheduler = Executors.newSingleThreadScheduledExecutor(
                 new DaemonThreadFactory(ILogger.ofJava(logger), XaeroHandler.class)
         );
-        this.sender = new XaeroLevelMapSender(logger, plugin, channelName, configPath, scheduler);
+        this.listener = new XaeroSpigotListener(logger, plugin, channelName,
+                new XaeroLevelMapSender(logger, plugin, channelName, configPath, scheduler)
+        );
     }
 
     public void init() throws InitializationException {
-        plugin.registerOutgoingChannel(channelName);
-        plugin.getServer().getPluginManager().registerEvents(this, plugin);
-        logger.fine("Event listener has been registered");
+        listener.init();
     }
 
     @Override
     public void cleanUp() {
-        plugin.unregisterOutgoingChannel(channelName);
-        HandlerList.unregisterAll(this);
-        logger.fine("Event listener has been unregistered");
+        listener.cleanUp();
         scheduler.shutdown();
-    }
-
-    @EventHandler(priority = EventPriority.MONITOR)
-    public void onPlayerJoined(PlayerJoinEvent event) {
-        sendPacket(event, XaeroLevelMapSender.EventSource.JOIN);
-    }
-
-    @EventHandler(priority = EventPriority.MONITOR)
-    public void onWorldChanged(PlayerChangedWorldEvent event) {
-        sendPacket(event, XaeroLevelMapSender.EventSource.WORLD_CHANGE);
-    }
-
-    private void sendPacket(PlayerEvent event, XaeroLevelMapSender.EventSource source) {
-        sender.sendPacket(event.getPlayer(), source);
     }
 
     public static class Factory implements Handler.Factory<MapModCompanion> {

--- a/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroLevelMapSender.java
+++ b/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroLevelMapSender.java
@@ -1,0 +1,85 @@
+package com.turikhay.mc.mapmodcompanion.spigot;
+
+import com.turikhay.mc.mapmodcompanion.LevelMapProperties;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.UUID;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+class XaeroLevelMapSender {
+    private final Logger logger;
+    private final MapModCompanion plugin;
+    private final String channelName;
+    private final String configPath;
+    private final ScheduledExecutorService scheduler;
+
+    XaeroLevelMapSender(Logger logger, MapModCompanion plugin, String channelName, String configPath, ScheduledExecutorService scheduler) {
+        this.logger = logger;
+        this.plugin = plugin;
+        this.channelName = channelName;
+        this.configPath = configPath;
+        this.scheduler = scheduler;
+    }
+
+    void sendPacket(Player p, EventSource source) {
+        World world = p.getWorld();
+        int id = plugin.getRegistry().getId(world);
+        byte[] payload = LevelMapProperties.Serializer.instance().serialize(id);
+        SendPayloadTask task = new SendPayloadTask(logger, plugin, p.getUniqueId(), channelName, payload, world.getUID());
+        int repeatTimes = plugin.getConfig().getInt(
+                configPath + ".events." + source.name().toLowerCase(Locale.ROOT) + ".repeat_times",
+                1
+        );
+        if (repeatTimes > 1) {
+            for (int i = 0; i < repeatTimes; i++) {
+                scheduler.schedule(task, i, TimeUnit.SECONDS);
+            }
+        } else {
+            task.run();
+        }
+    }
+
+    enum EventSource {
+        JOIN,
+        WORLD_CHANGE,
+    }
+
+    private static class SendPayloadTask implements Runnable {
+        private final Logger logger;
+        private final MapModCompanion plugin;
+        private final UUID playerId;
+        private final String channelName;
+        private final byte[] payload;
+        private final UUID expectedWorld;
+
+        public SendPayloadTask(Logger logger, MapModCompanion plugin, UUID playerId, String channelName, byte[] payload,
+                               UUID expectedWorld) {
+            this.logger = logger;
+            this.plugin = plugin;
+            this.playerId = playerId;
+            this.channelName = channelName;
+            this.payload = payload;
+            this.expectedWorld = expectedWorld;
+        }
+
+        @Override
+        public void run() {
+            Player player = plugin.getServer().getPlayer(playerId);
+            if (player == null) {
+                return;
+            }
+            UUID world = player.getWorld().getUID();
+            if (!world.equals(expectedWorld)) {
+                logger.fine("Skipping sending Xaero's LevelMapProperties to " + player.getName() + ": unexpected world");
+                return;
+            }
+            logger.fine(() -> "Sending Xaero's LevelMapProperties to " + player.getName() + ": " + Arrays.toString(payload));
+            player.sendPluginMessage(plugin, channelName, payload);
+        }
+    }
+}

--- a/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroLevelMapSender.java
+++ b/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroLevelMapSender.java
@@ -30,7 +30,10 @@ class XaeroLevelMapSender {
         World world = p.getWorld();
         int id = plugin.getRegistry().getId(world);
         byte[] payload = LevelMapProperties.Serializer.instance().serialize(id);
-        SendPayloadTask task = new SendPayloadTask(logger, plugin, p.getUniqueId(), channelName, payload, world.getUID());
+        SendPayloadTask task = new SendPayloadTask(
+                logger, plugin, p.getUniqueId(), channelName,
+                payload, world.getUID(), source
+        );
         int repeatTimes = plugin.getConfig().getInt(
                 configPath + ".events." + source.name().toLowerCase(Locale.ROOT) + ".repeat_times",
                 1
@@ -47,6 +50,7 @@ class XaeroLevelMapSender {
     enum EventSource {
         JOIN,
         WORLD_CHANGE,
+        RESPAWN_PACKET,
     }
 
     private static class SendPayloadTask implements Runnable {
@@ -56,15 +60,17 @@ class XaeroLevelMapSender {
         private final String channelName;
         private final byte[] payload;
         private final UUID expectedWorld;
+        private final EventSource source;
 
         public SendPayloadTask(Logger logger, MapModCompanion plugin, UUID playerId, String channelName, byte[] payload,
-                               UUID expectedWorld) {
+                               UUID expectedWorld, EventSource source) {
             this.logger = logger;
             this.plugin = plugin;
             this.playerId = playerId;
             this.channelName = channelName;
             this.payload = payload;
             this.expectedWorld = expectedWorld;
+            this.source = source;
         }
 
         @Override
@@ -75,10 +81,10 @@ class XaeroLevelMapSender {
             }
             UUID world = player.getWorld().getUID();
             if (!world.equals(expectedWorld)) {
-                logger.fine("Skipping sending Xaero's LevelMapProperties to " + player.getName() + ": unexpected world");
+                logger.fine("Skipping sending Xaero's LevelMapProperties (from " + source + ") to " + player.getName() + ": unexpected world");
                 return;
             }
-            logger.fine(() -> "Sending Xaero's LevelMapProperties to " + player.getName() + ": " + Arrays.toString(payload));
+            logger.fine(() -> "Sending Xaero's LevelMapProperties (from " + source + ") to " + player.getName() + ": " + Arrays.toString(payload));
             player.sendPluginMessage(plugin, channelName, payload);
         }
     }

--- a/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroListener.java
+++ b/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroListener.java
@@ -6,6 +6,5 @@ import com.turikhay.mc.mapmodcompanion.InitializationException;
 import java.util.Set;
 
 public interface XaeroListener extends Disposable {
-    String name();
     void init(Set<String> neighbors) throws InitializationException;
 }

--- a/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroListener.java
+++ b/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroListener.java
@@ -1,0 +1,11 @@
+package com.turikhay.mc.mapmodcompanion.spigot;
+
+import com.turikhay.mc.mapmodcompanion.Disposable;
+import com.turikhay.mc.mapmodcompanion.InitializationException;
+
+import java.util.Set;
+
+public interface XaeroListener extends Disposable {
+    String name();
+    void init(Set<String> neighbors) throws InitializationException;
+}

--- a/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroRespawnPacketListener.java
+++ b/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroRespawnPacketListener.java
@@ -1,0 +1,46 @@
+package com.turikhay.mc.mapmodcompanion.spigot;
+
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.event.*;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+
+import java.util.Set;
+
+class XaeroRespawnPacketListener implements XaeroListener, PacketListener {
+    public static final String NAME = "PacketEvents";
+
+    private final XaeroLevelMapSender sender;
+    private PacketListenerCommon listenerRef;
+
+    XaeroRespawnPacketListener(XaeroLevelMapSender sender) {
+        this.sender = sender;
+    }
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void init(Set<String> neighbors) {
+        this.listenerRef = events().registerListener(this, PacketListenerPriority.MONITOR);
+    }
+
+    @Override
+    public void cleanUp() {
+        if (listenerRef != null) {
+            events().unregisterListener(listenerRef);
+        }
+    }
+
+    @Override
+    public void onPacketSend(PacketSendEvent event) {
+        if (event.getPacketType() == PacketType.Play.Server.RESPAWN) {
+            sender.sendPacket(event.getPlayer(), XaeroLevelMapSender.EventSource.RESPAWN_PACKET);
+        }
+    }
+
+    private static EventManager events() {
+        return PacketEvents.getAPI().getEventManager();
+    }
+}

--- a/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroRespawnPacketListener.java
+++ b/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroRespawnPacketListener.java
@@ -17,11 +17,6 @@ class XaeroRespawnPacketListener implements XaeroListener, PacketListener {
     }
 
     @Override
-    public String name() {
-        return NAME;
-    }
-
-    @Override
     public void init(Set<String> neighbors) {
         this.listenerRef = events().registerListener(this, PacketListenerPriority.MONITOR);
     }

--- a/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroSpigotListener.java
+++ b/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroSpigotListener.java
@@ -26,6 +26,12 @@ class XaeroSpigotListener implements Disposable, Listener {
         this.sender = sender;
     }
 
+    @Override
+    public String name() {
+        return "Spigot";
+    }
+
+    @Override
     public void init() throws InitializationException {
         plugin.registerOutgoingChannel(channelName);
         plugin.getServer().getPluginManager().registerEvents(this, plugin);

--- a/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroSpigotListener.java
+++ b/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroSpigotListener.java
@@ -1,6 +1,5 @@
 package com.turikhay.mc.mapmodcompanion.spigot;
 
-import com.turikhay.mc.mapmodcompanion.Disposable;
 import com.turikhay.mc.mapmodcompanion.InitializationException;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -10,9 +9,10 @@ import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.bukkit.event.player.PlayerEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 
+import java.util.Set;
 import java.util.logging.Logger;
 
-class XaeroSpigotListener implements Disposable, Listener {
+class XaeroSpigotListener implements XaeroListener, Listener {
 
     private final Logger logger;
     private final MapModCompanion plugin;
@@ -31,11 +31,18 @@ class XaeroSpigotListener implements Disposable, Listener {
         return "Spigot";
     }
 
+    private boolean ignoreWorldChange;
+
     @Override
     public void init(Set<String> neighbors) throws InitializationException {
         plugin.registerOutgoingChannel(channelName);
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
         logger.fine("Event listener has been registered");
+
+        if (neighbors.contains(XaeroRespawnPacketListener.NAME)) {
+            logger.info("Spigot listener will ignore world change events because respawn packets are already being listened");
+            ignoreWorldChange = true;
+        }
     }
 
     @Override
@@ -53,6 +60,9 @@ class XaeroSpigotListener implements Disposable, Listener {
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onWorldChanged(PlayerChangedWorldEvent event) {
+        if (ignoreWorldChange) {
+            return;
+        }
         sendPacket(event, XaeroLevelMapSender.EventSource.WORLD_CHANGE);
     }
 

--- a/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroSpigotListener.java
+++ b/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroSpigotListener.java
@@ -1,0 +1,56 @@
+package com.turikhay.mc.mapmodcompanion.spigot;
+
+import com.turikhay.mc.mapmodcompanion.Disposable;
+import com.turikhay.mc.mapmodcompanion.InitializationException;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerChangedWorldEvent;
+import org.bukkit.event.player.PlayerEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+
+import java.util.logging.Logger;
+
+class XaeroSpigotListener implements Disposable, Listener {
+
+    private final Logger logger;
+    private final MapModCompanion plugin;
+    private final String channelName;
+    private final XaeroLevelMapSender sender;
+
+    XaeroSpigotListener(Logger logger, MapModCompanion plugin, String channelName, XaeroLevelMapSender sender) {
+        this.logger = logger;
+        this.plugin = plugin;
+        this.channelName = channelName;
+        this.sender = sender;
+    }
+
+    public void init() throws InitializationException {
+        plugin.registerOutgoingChannel(channelName);
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+        logger.fine("Event listener has been registered");
+    }
+
+    @Override
+    public void cleanUp() {
+        plugin.unregisterOutgoingChannel(channelName);
+        HandlerList.unregisterAll(this);
+        logger.fine("Event listener has been unregistered");
+    }
+
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onPlayerJoined(PlayerJoinEvent event) {
+        sendPacket(event, XaeroLevelMapSender.EventSource.JOIN);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onWorldChanged(PlayerChangedWorldEvent event) {
+        sendPacket(event, XaeroLevelMapSender.EventSource.WORLD_CHANGE);
+    }
+
+    private void sendPacket(PlayerEvent event, XaeroLevelMapSender.EventSource source) {
+        sender.sendPacket(event.getPlayer(), source);
+    }
+}

--- a/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroSpigotListener.java
+++ b/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroSpigotListener.java
@@ -32,7 +32,7 @@ class XaeroSpigotListener implements Disposable, Listener {
     }
 
     @Override
-    public void init() throws InitializationException {
+    public void init(Set<String> neighbors) throws InitializationException {
         plugin.registerOutgoingChannel(channelName);
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
         logger.fine("Event listener has been registered");

--- a/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroSpigotListener.java
+++ b/spigot/src/main/java/com/turikhay/mc/mapmodcompanion/spigot/XaeroSpigotListener.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import java.util.logging.Logger;
 
 class XaeroSpigotListener implements XaeroListener, Listener {
+    public static final String NAME = "Spigot";
 
     private final Logger logger;
     private final MapModCompanion plugin;
@@ -24,11 +25,6 @@ class XaeroSpigotListener implements XaeroListener, Listener {
         this.plugin = plugin;
         this.channelName = channelName;
         this.sender = sender;
-    }
-
-    @Override
-    public String name() {
-        return "Spigot";
     }
 
     private boolean ignoreWorldChange;

--- a/spigot/src/main/resources/config.yml
+++ b/spigot/src/main/resources/config.yml
@@ -34,6 +34,8 @@ xaero:
         repeat_times: 3
       world_change:
         enabled: true
+      respawn_packet:
+        enabled: true
   # Supported since 1.10.0 (Minecraft 1.8.9)
   mini_map:
     enabled: true
@@ -43,6 +45,8 @@ xaero:
         # Sometimes the mod doesn't pick up the initial packet
         repeat_times: 3
       world_change:
+        enabled: true
+      respawn_packet:
         enabled: true
 
 # ID overrides

--- a/tests_e2e/run.py
+++ b/tests_e2e/run.py
@@ -248,6 +248,24 @@ def copy_proxy_files():
         _to / "Dockerfile",
     )
 
+def download_plugin(plugin_jar, url):
+    plugin_source_file = test_env_dir / plugin_jar
+    if not plugin_source_file.is_file():
+        logger.info(f"Downloading {plugin_jar}")
+        response = requests.get(url)
+        response.raise_for_status()
+        try:
+            with open(plugin_source_file, "wb") as f:
+                f.write(response.content)
+        except Exception as e:
+            plugin_source_file.unlink(missing_ok=True)
+            raise e
+    logger.info(f"Copying {plugin_jar}")
+    copyfile(
+        plugin_source_file,
+        files_dir_of(server_name) / "plugins" / plugin_jar,
+    )
+
 
 if __name__ == "__main__":
     servers = [
@@ -391,22 +409,10 @@ if __name__ == "__main__":
                 'JVM_XX_OPTS=' + " ".join(jvm_opts)
             ]
         docker_compose_file_contents["services"][server_name] = server_desc
+
         if "protocollib" in version_info and version_info["protocollib"] == True:
-            protocollib_source_file = test_env_dir / "ProtocolLib.jar"
-            if not protocollib_source_file.is_file():
-                logger.info("Downloading ProtocolLib")
-                data = requests.get(f"https://github.com/dmulloy2/ProtocolLib/releases/download/{PROTOCOLLIB_VERSION}/ProtocolLib.jar").content
-                try:
-                    with open(protocollib_source_file, "wb") as f:
-                        f.write(data)
-                except Exception as e:
-                    protocollib_source_file.unlink(missing_ok=True)
-                    raise e
-            logger.info("Copying ProtocolLib")
-            copyfile(
-                protocollib_source_file,
-                files_dir_of(server_name) / "plugins" / "ProtocolLib.jar",
-            )
+            download_plugin("ProtocolLib.jar", f"https://github.com/dmulloy2/ProtocolLib/releases/download/{PROTOCOLLIB_VERSION}/ProtocolLib.jar")
+
         world_dir = files_dir_of(server_name) / "world"
         copy_clean(
             PARENT_DIR / "saves" / world_version / server_name,

--- a/tests_e2e/run.py
+++ b/tests_e2e/run.py
@@ -16,6 +16,7 @@ logger = getLogger("tests_e2e")
 PARENT_DIR = Path(path.realpath(__file__)).parent
 
 PROTOCOLLIB_VERSION = "4.8.0"
+PACKETEVENTS_VERSION = "2.12.1"
 
 SERVER_OVERRIDES = {
     'red': 42,
@@ -412,6 +413,15 @@ if __name__ == "__main__":
 
         if "protocollib" in version_info and version_info["protocollib"] == True:
             download_plugin("ProtocolLib.jar", f"https://github.com/dmulloy2/ProtocolLib/releases/download/{PROTOCOLLIB_VERSION}/ProtocolLib.jar")
+
+        dl_packetevents = False
+        if "packetevents" in version_info and version_info["packetevents"] == True:
+            dl_packetevents = True
+        elif server_type in ("folia",):
+            logger.info("Selected server type is Folia: downloading PacketEvents automatically")
+            dl_packetevents = True
+        if dl_packetevents:
+            download_plugin("PacketEvents.jar", f"https://github.com/retrooper/packetevents/releases/download/v{PACKETEVENTS_VERSION}/packetevents-spigot-{PACKETEVENTS_VERSION}.jar")
 
         world_dir = files_dir_of(server_name) / "world"
         copy_clean(

--- a/tests_e2e/run.py
+++ b/tests_e2e/run.py
@@ -417,10 +417,9 @@ if __name__ == "__main__":
         dl_packetevents = False
         if "packetevents" in version_info and version_info["packetevents"] == True:
             dl_packetevents = True
-        # TODO test
-        # elif server_type in ("folia",):
-        #     logger.info("Selected server type is Folia: downloading PacketEvents automatically")
-        #     dl_packetevents = True
+        elif server_type in ("folia",):
+            logger.info("Selected server type is Folia: downloading PacketEvents automatically")
+            dl_packetevents = True
         if dl_packetevents:
             download_plugin("PacketEvents.jar", f"https://github.com/retrooper/packetevents/releases/download/v{PACKETEVENTS_VERSION}/packetevents-spigot-{PACKETEVENTS_VERSION}.jar")
 

--- a/tests_e2e/run.py
+++ b/tests_e2e/run.py
@@ -417,9 +417,10 @@ if __name__ == "__main__":
         dl_packetevents = False
         if "packetevents" in version_info and version_info["packetevents"] == True:
             dl_packetevents = True
-        elif server_type in ("folia",):
-            logger.info("Selected server type is Folia: downloading PacketEvents automatically")
-            dl_packetevents = True
+        # TODO test
+        # elif server_type in ("folia",):
+        #     logger.info("Selected server type is Folia: downloading PacketEvents automatically")
+        #     dl_packetevents = True
         if dl_packetevents:
             download_plugin("PacketEvents.jar", f"https://github.com/retrooper/packetevents/releases/download/v{PACKETEVENTS_VERSION}/packetevents-spigot-{PACKETEVENTS_VERSION}.jar")
 

--- a/tests_e2e/run.py
+++ b/tests_e2e/run.py
@@ -15,6 +15,8 @@ logger = getLogger("tests_e2e")
 
 PARENT_DIR = Path(path.realpath(__file__)).parent
 
+PROTOCOLLIB_VERSION = "4.8.0"
+
 SERVER_OVERRIDES = {
     'red': 42,
     'blue': 2000,
@@ -393,7 +395,7 @@ if __name__ == "__main__":
             protocollib_source_file = test_env_dir / "ProtocolLib.jar"
             if not protocollib_source_file.is_file():
                 logger.info("Downloading ProtocolLib")
-                data = requests.get("https://github.com/dmulloy2/ProtocolLib/releases/download/4.8.0/ProtocolLib.jar").content
+                data = requests.get(f"https://github.com/dmulloy2/ProtocolLib/releases/download/{PROTOCOLLIB_VERSION}/ProtocolLib.jar").content
                 try:
                     with open(protocollib_source_file, "wb") as f:
                         f.write(data)


### PR DESCRIPTION
Fixes #224

Due to Folia's multi-threaded architecture, generic teleport events are almost never fired. To detect players changing dimensions, we use `PlayerChangedWorldEvent`, but in Folia that event _only_ fires after death.

As a fallback, we listen for the [Respawn packet (0x50)](https://minecraft.wiki/w/Java_Edition_protocol/Packets#Respawn). It is a reliable way to detect players teleporting between worlds.

This implementation uses the [PacketEvents library](https://github.com/retrooper/packetevents) for packet handling. While ProtocolLib is still recommended for older versions (see #8), it is less well-suited for Folia due to its uneven release cadence. ProtocolLib support for this specific use case may be added in the future if there is demand.

▶️ [**Download PacketEvents here**](https://modrinth.com/plugin/packetevents/versions?l=folia)